### PR TITLE
Support current leiningen 2.8.3 and updated aot build dependencies

### DIFF
--- a/ClojureScript/replete/project.clj
+++ b/ClojureScript/replete/project.clj
@@ -1,6 +1,6 @@
 (defproject replete "0.1.0"
   :dependencies [[cljsjs/parinfer "1.8.1-0"]]
-  :plugins [[lein-tools-deps "0.4.1"]
+  :plugins [[lein-tools-deps "0.4.3"]
             [lein-cljsbuild "1.1.7"]]
   :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
   :lein-tools-deps/config {:config-files [:install :user :project]}

--- a/ClojureScript/replete/script/build
+++ b/ClojureScript/replete/script/build
@@ -46,7 +46,7 @@ mkdir -p aot-cache
 lein deps
 M2_REPO=~/.m2/repository
 echo "AOT compiling macros"
-../../../planck/planck-c/build/planck -q -k aot-cache -c $M2_REPO/andare/andare/0.9.0/andare-0.9.0.jar:$M2_REPO/org/clojure/test.check/0.10.0-alpha2/test.check-0.10.0-alpha2.jar:$M2_REPO/chivorcam/chivorcam/0.3.0/chivorcam-0.3.0.jar <<REPL_INPUT
+../../../planck/planck-c/build/planck -q -k aot-cache -c $M2_REPO/andare/andare/0.9.0/andare-0.9.0.jar:$M2_REPO/org/clojure/test.check/0.10.0-alpha3/test.check-0.10.0-alpha3.jar:$M2_REPO/chivorcam/chivorcam/1.0.0/chivorcam-1.0.0.jar <<REPL_INPUT
 (require '[clojure.test.check.clojure-test :include-macros true])
 (require-macros
   'chivorcam.core


### PR DESCRIPTION
I had to upgrade `lein-tools-deps`  from `0.4.1` to `0.4.3` in order to get the ClojureScript build running. 
Furthermore the build script failed because it could not find the current versions of `test.check` `0.10.0-alpha3` and `chivorcam` `1.0.0`.