### PR TITLE
Inability to require replete.io owing to rrb-vector macros

### DIFF
--- a/ClojureScript/replete/deps.edn
+++ b/ClojureScript/replete/deps.edn
@@ -1,4 +1,4 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.0"}
         org.clojure/clojurescript {:mvn/version "1.10.520"}
         github-replete-repl/replete-shared {:git/url "https://github.com/replete-repl/replete-shared"
-                                            :sha "00307566f2f0fc5e83fcb5baa79b3fd85cd4d226"}}}
+                                            :sha "14537e549988902edc9dfdfc36f85245eb4e103f"}}}

--- a/ClojureScript/replete/script/build.clj
+++ b/ClojureScript/replete/script/build.clj
@@ -41,6 +41,10 @@
 (copy-source "cljs/core/specs/alpha.cljc")
 (copy-source "cljs/core/specs/alpha.cljs")
 
+(let [target (io/file "out/clojure/core/rrb_vector/macros.clj")]
+   (io/make-parents target)
+   (io/copy (io/reader "https://replete-repl.org/releases/CRRBV-16-macros.clj") target))
+
 (let [res (io/resource "cljs/core.cljs.cache.aot.edn")
       cache (read-string (slurp res))]
   (doseq [key (keys cache)]


### PR DESCRIPTION
Fixes #49 